### PR TITLE
Reuse categories from subjects if exists

### DIFF
--- a/email_tracker/models.py
+++ b/email_tracker/models.py
@@ -13,10 +13,17 @@ class EmailCategoryManager(models.Manager):
         """
         Get or create category for given EmailMessage object
         """
-        title = message.extra_headers.get('X-Category')
-        if not title:
-            return
-        instance, created = self.get_or_create(title=title)
+        # Try to get category from extra headers
+        category = message.extra_headers.get('X-Category')
+        if category:
+            instance, created = self.get_or_create(title=category)
+        else:
+            # If there is existing category which is same as the subject
+            # then use that, but does not create new category for every subject
+            try:
+                instance = self.get(title=message.subject)
+            except self.model.DoesNotExist:
+                return
         return instance
 
 

--- a/email_tracker/tests/__init__.py
+++ b/email_tracker/tests/__init__.py
@@ -1,5 +1,6 @@
 import django
 
 if django.VERSION < (1, 7):
+    from .test_models import *  # NOQA
     from .test_backend import *  # NOQA
     from .test_admin import *  # NOQA

--- a/email_tracker/tests/test_models.py
+++ b/email_tracker/tests/test_models.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+
+
+from django.core.mail import EmailMessage
+from django.test import TestCase
+from email_tracker.models import TrackedEmail, EmailCategory
+
+
+class EmailTrackerAdminTestCase(TestCase):
+    def setUp(self):
+        super(EmailTrackerAdminTestCase, self).setUp()
+        self.category = EmailCategory.objects.create(title='Test Mail')
+
+    def test_create_mail_from_message(self):
+
+        message = EmailMessage(
+            subject='Test Subject',
+            body='Text body',
+            from_email='from@example.com',
+            to=['to@example.com', 'to2@example.com'],
+            cc=['cc@example.com'],
+            bcc=['bcc@example.com'],
+        )
+
+        tracked_email = TrackedEmail.objects.create_from_message(message)
+        self.assertEqual(tracked_email.subject, 'Test Subject')
+        self.assertEqual(tracked_email.body, 'Text body')
+        self.assertEqual(tracked_email.from_email, 'from@example.com')
+        self.assertEqual(tracked_email.recipients, 'to@example.com, to2@example.com, cc@example.com, bcc@example.com')
+        self.assertEqual(tracked_email.cc, 'cc@example.com')
+        self.assertEqual(tracked_email.bcc, 'bcc@example.com')
+        self.assertIsNone(tracked_email.category)
+
+    def test_autocreate_category_from_message_headers(self):
+        message = EmailMessage(
+            subject='Test Subject',
+            body='Text body',
+            from_email='from@example.com',
+            to=['to@example.com'],
+        )
+        message.extra_headers['X-Category'] = 'Some category'
+
+        tracked_email = TrackedEmail.objects.create_from_message(message)
+        self.assertIsNotNone(tracked_email.category)
+        self.assertEqual(tracked_email.category.title, 'Some category')
+
+    def test_reuse_category_from_message_headers(self):
+        message = EmailMessage(
+            subject='Test Subject',
+            body='Text body',
+            from_email='from@example.com',
+            to=['to@example.com'],
+        )
+        message.extra_headers['X-Category'] = self.category.title
+
+        tracked_email = TrackedEmail.objects.create_from_message(message)
+        self.assertEqual(tracked_email.category, self.category)
+
+    def test_reuse_category_from_subject(self):
+        message = EmailMessage(
+            subject=self.category.title,
+            body='Text body',
+            from_email='from@example.com',
+            to=['to@example.com'],
+        )
+
+        tracked_email = TrackedEmail.objects.create_from_message(message)
+        self.assertEqual(tracked_email.category, self.category)


### PR DESCRIPTION
This way if we create categories in the admin and the name of the category match with the name of the subject (an there is no `X-Category` header) then this category will be assigned to the email.

This will allow easy filtering of transactional mails with the same subject without expensive lookup in subject field.